### PR TITLE
v1.2.4: Corrige permissões do auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -7,6 +7,10 @@ on:
 env:
   NODE_VERSION: '22'
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   auto-tag:
     name: 🏷️ Create Release Tag
@@ -87,8 +91,8 @@ jobs:
         if: steps.tag-check.outputs.exists == 'false'
         run: |
           # Configurar git
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           
           # Gerar release notes baseado nos commits desde a última tag
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
@@ -109,7 +113,8 @@ jobs:
           - **Author**: ${{ github.actor }}
           - **Deployment**: Automatic via Coolify"
           
-          # Push da tag
+          # Push da tag usando HTTPS com token
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
           git push origin "${{ steps.version.outputs.VERSION }}"
           
           echo "✅ Tag ${{ steps.version.outputs.VERSION }} criada e enviada!"


### PR DESCRIPTION
## 🔧 Hotfix - Correção de Permissões Auto-Tag

### 📋 **Problema:**
- Workflow auto-tag falhando com erro 403 (Permission denied)
- GitHub Actions bot não tinha permissões para criar e push tags

### 🔧 **Solução:**
- ✅ Adicionadas permissões `contents: write` e `actions: read`
- ✅ Configuração correta do git user (github-actions[bot])
- ✅ URL remota com token de acesso para push

### ✅ **Validações:**
- [x] 🔍 ESLint sem erros
- [x] 🧪 Testes passando  
- [x] 🐳 Container buildando
- [x] 🔒 Security scan ok

### 🚀 **Deploy:**
- [x] 🎯 Versão especificada no título (v1.2.4)
- [x] 🏷️ Tag será criada automaticamente após merge
- [x] 🌟 Deploy automático ativado

**Tipo**: 🐛 Hotfix  
**Breaking Changes**: ❌ Não  
**Criticidade**: 🔥 Alta (bloqueia releases)